### PR TITLE
Add OpenShift Support

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,35 @@
+### Deploy Tech maturity by Ticketmaster on OpenShift
+
+Two different templates are provided, `ephemeral` with no data persistence, and `persistent` with data persistence backed by PostgreSQL.
+
+To instantiate the template, run the following.
+
+1. Create a project in which to host your jobs.
+	```
+	oc new-project <project>
+	```
+
+2a. Instantiate the `ephemeral` template
+```
+oc process -f techmaturity-ephemeral.yml \
+-p APP_SA=techmaturity-sa \
+-p HOSTNAME=<application-name>-<project>.<default-domain-suffix> \
+-p APP_VERSION=2.0.0 | oc create -f-
+```
+
+2a. Instantiate the `persistent` emplate
+```
+oc process -f techmaturity-persistent.yml \
+-p APP_SA=techmaturity-sa \
+-p APPLICATION_NAME=techmaturity \
+-p HOSTNAME=<application-name>-<project>.<default-domain-suffix> \
+-p APP_VERSION=2.0.0 \
+-p POSTGRESQL_ADMIN_PASSWORD=<db_admin_pass> | oc create -f-
+```
+
+3. Add the Service Account to the anyuid Security Context
+```
+oc adm policy add-scc-to-user anyuid system:serviceaccount:<project>:<app_service_account>
+```
+
+NOTE: These are the minimal parameters the templates accept. Check the template definition for aditional parameters.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -4,32 +4,32 @@ Two different templates are provided, `ephemeral` with no data persistence, and 
 
 To instantiate the template, run the following.
 
-1. Create a project in which to host your jobs.
+1. Create a project in which to host your application.
 	```
 	oc new-project <project> --display-name="Tech maturity by Ticketmaster" --description="Tech maturity by Ticketmaster."
 	```
 
-2a. Instantiate the `ephemeral` template
-```
-oc process -f techmaturity-ephemeral.yml \
--p APP_SA=techmaturity-sa \
--p HOSTNAME=<application-name>-<project>.<default-domain-suffix> \
--p APP_VERSION=2.0.0 | oc create -f-
-```
+2. Ephemeral deployment: instantiate the `ephemeral` template
+	```
+	oc process -f techmaturity-ephemeral.yml \
+	-p APP_SA=techmaturity-sa \
+	-p HOSTNAME=<application-name>-<project>.<default-domain-suffix> \
+	-p APP_VERSION=2.0.0 | oc create -f-
+	```
 
-2a. Instantiate the `persistent` emplate
-```
-oc process -f techmaturity-persistent.yml \
--p APP_SA=techmaturity-sa \
--p APPLICATION_NAME=techmaturity \
--p HOSTNAME=<application-name>-<project>.<default-domain-suffix> \
--p APP_VERSION=2.0.0 \
--p POSTGRESQL_ADMIN_PASSWORD=<db_admin_pass> | oc create -f-
-```
+2. Persistent deployment: instantiate the `persistent` template
+	```
+	oc process -f techmaturity-persistent.yml \
+	-p APP_SA=techmaturity-sa \
+	-p APPLICATION_NAME=techmaturity \
+	-p HOSTNAME=<application-name>-<project>.<default-domain-suffix> \
+	-p APP_VERSION=2.0.0 \
+	-p POSTGRESQL_ADMIN_PASSWORD=<db_admin_pass> | oc create -f-
+	```
 
 3. Add the Service Account to the anyuid Security Context
-```
-oc adm policy add-scc-to-user anyuid system:serviceaccount:<project>:<app_service_account>
-```
+	```
+	oc adm policy add-scc-to-user anyuid system:serviceaccount:<project>:<app_service_account>
+	```
 
 NOTE: These are the minimal parameters the templates accept. Check the template definition for aditional parameters.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -6,7 +6,7 @@ To instantiate the template, run the following.
 
 1. Create a project in which to host your jobs.
 	```
-	oc new-project <project>
+	oc new-project <project> --display-name="Tech maturity by Ticketmaster" --description="Tech maturity by Ticketmaster."
 	```
 
 2a. Instantiate the `ephemeral` template

--- a/openshift/techmaturity-ephemeral.yml
+++ b/openshift/techmaturity-ephemeral.yml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: techmaturity
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ${APP_SA}
+    labels:
+      app: ${APPLICATION_NAME}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    tags:
+    - name: "${APP_VERSION}"
+      from:
+        kind: DockerImage
+        name: docker.io/ticketmaster/techmaturity:${APP_VERSION}
+      importPolicy: {}
+      annotations:
+        description: Tech maturity by Ticketmaster
+        tags: ticketmaster,techmaturity
+        version: "${APP_VERSION}"
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    replicas: 1
+    selector:
+      app: ${APPLICATION_NAME}
+      deploymentconfig: ${APPLICATION_NAME}
+    strategy:
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: ${APPLICATION_NAME}
+          deploymentconfig: ${APPLICATION_NAME}
+      spec:
+        serviceAccountName: ${APP_SA}
+        containers:
+        - image: " "
+          imagePullPolicy: Always
+          name: ${APPLICATION_NAME}
+          ports:
+          - containerPort: 3000
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          readinessProbe:
+              tcpSocket:
+                port: 3000
+              initialDelaySeconds: 3
+              timeoutSeconds: 1
+              periodSeconds: 20
+              successThreshold: 1
+              failureThreshold: 3
+          livenessProbe:
+              tcpSocket:
+                port: 3000
+              initialDelaySeconds: 3
+              timeoutSeconds: 1
+              periodSeconds: 10
+              successThreshold: 1
+              failureThreshold: 3
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${APPLICATION_NAME}
+        from:
+          kind: ImageStreamTag
+          name: ${APPLICATION_NAME}:${APP_VERSION}
+      type: ImageChange
+- apiVersion: v1
+  kind: Route
+  id: ${APPLICATION_NAME}-https
+  metadata:
+    annotations:
+      description: Route for application's https service.
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    host: ${HOSTNAME}
+    port:
+      targetPort: 3000-tcp
+    tls:
+      termination: edge
+    to:
+      kind: Service
+      name: ${APPLICATION_NAME}
+      weight: 100
+    wildcardPolicy: None
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    ports:
+    - name: 3000-tcp
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+    selector:
+      deploymentconfig: ${APPLICATION_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+parameters:
+- description: The name for the application.
+  name: APPLICATION_NAME
+  required: true
+  value: techmaturity
+- description: The service account name that will run the container
+  name: APP_SA
+  required: true
+  value: techmaturity-sa
+- description: 'Custom hostname for https service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix>'
+  name: HOSTNAME
+  required: true
+- name: APP_VERSION
+  displayName: Tech maturity container Tag version
+  description: 'Tech maturity container Tag version'
+  value: "2.0.0"
+  required: true

--- a/openshift/techmaturity-persistent.yml
+++ b/openshift/techmaturity-persistent.yml
@@ -1,0 +1,358 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: techmaturity
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ${APP_SA}
+    labels:
+      app: ${APPLICATION_NAME}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    tags:
+    - name: "${APP_VERSION}"
+      from:
+        kind: DockerImage
+        name: docker.io/ticketmaster/techmaturity:${APP_VERSION}
+      importPolicy: {}
+      annotations:
+        description: Tech maturity by Ticketmaster
+        tags: ticketmaster,techmaturity
+        version: "${APP_VERSION}"
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+      template.openshift.io/expose-password: '{.data[''database-password'']}'
+      template.openshift.io/expose-username: '{.data[''database-user'']}'
+      template.openshift.io/expose-admin: '{.data[''database-admin'']}'
+    name: ${DATABASE_SERVICE_NAME}
+  stringData:
+    database-name: ${POSTGRESQL_DATABASE}
+    database-password: ${POSTGRESQL_PASSWORD}
+    database-user: ${POSTGRESQL_USER}
+    database-admin: ${POSTGRESQL_ADMIN_PASSWORD}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    replicas: 1
+    selector:
+      app: ${APPLICATION_NAME}
+      deploymentconfig: ${APPLICATION_NAME}
+    strategy:
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: ${APPLICATION_NAME}
+          deploymentconfig: ${APPLICATION_NAME}
+      spec:
+        serviceAccountName: ${APP_SA}
+        containers:
+        - image: " "
+          imagePullPolicy: Always
+          name: ${APPLICATION_NAME}
+          ports:
+          - containerPort: 3000
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /techmaturity/config/database.yml
+            name: dbconfig
+            subPath: database.yml
+          readinessProbe:
+              tcpSocket:
+                port: 3000
+              initialDelaySeconds: 3
+              timeoutSeconds: 1
+              periodSeconds: 20
+              successThreshold: 1
+              failureThreshold: 3
+          livenessProbe:
+              tcpSocket:
+                port: 3000
+              initialDelaySeconds: 3
+              timeoutSeconds: 1
+              periodSeconds: 10
+              successThreshold: 1
+              failureThreshold: 3
+        volumes:
+        - configMap:
+            defaultMode: 420
+            name: techmaturity-db
+          name: dbconfig
+        initContainers:
+        - name: postgre-check
+          image: docker.io/alpine:latest
+          command:
+          - nc
+          - "-v"
+          - "postgresql"
+          - "5432"
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${APPLICATION_NAME}
+        from:
+          kind: ImageStreamTag
+          name: ${APPLICATION_NAME}:${APP_VERSION}
+      type: ImageChange
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      template: postgresql-persistent-template
+    name: postgresql
+  spec:
+    replicas: 1
+    selector:
+      name: postgresql
+    strategy:
+      activeDeadlineSeconds: 21600
+      recreateParams:
+        timeoutSeconds: 600
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: postgresql
+      spec:
+        containers:
+        - env:
+          - name: POSTGRESQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: postgresql
+          - name: POSTGRESQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: postgresql
+          - name: POSTGRESQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: postgresql
+          - name: POSTGRESQL_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-admin
+                name: postgresql
+          image: registry.access.redhat.com/rhscl/postgresql-95-rhel7
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 5432
+            timeoutSeconds: 1
+          name: postgresql
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c
+                'SELECT 1'
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 512Mi
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /var/lib/pgsql/data
+            name: postgresql-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: postgresql-data
+          persistentVolumeClaim:
+            claimName: postgresql
+    test: false
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - postgresql
+        from:
+          kind: ImageStreamTag
+          name: postgresql:9.5
+          namespace: openshift
+      type: ImageChange
+- apiVersion: v1
+  kind: Route
+  id: ${APPLICATION_NAME}-https
+  metadata:
+    annotations:
+      description: Route for application's https service.
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    host: ${HOSTNAME}
+    port:
+      targetPort: 3000-tcp
+    tls:
+      termination: edge
+    to:
+      kind: Service
+      name: ${APPLICATION_NAME}
+      weight: 100
+    wildcardPolicy: None
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    ports:
+    - name: postgresql
+      nodePort: 0
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      name: ${DATABASE_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    ports:
+    - name: 3000-tcp
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+    selector:
+      deploymentconfig: ${APPLICATION_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: techmaturity-db
+  data:
+    database.yml: |-
+      default: &default
+        adapter: postgresql
+        pool: 5
+        timeout: 5000
+        username: postgres
+        password: ${POSTGRESQL_ADMIN_PASSWORD}
+
+      production:
+        <<: *default
+        database: techmaturity
+        host: postgresql
+parameters:
+- description: The name for the application.
+  name: APPLICATION_NAME
+  required: true
+  value: techmaturity
+- description: The service account name that will run the container
+  name: APP_SA
+  required: true
+  value: techmaturity-sa
+- description: 'Custom hostname for https service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix>'
+  name: HOSTNAME
+  required: true
+- name: APP_VERSION
+  displayName: Tech maturity container Tag version
+  description: 'Tech maturity container Tag version'
+  value: "2.0.0"
+  required: true
+- description: The name of the OpenShift Service exposed for the database.
+  displayName: Database Service Name
+  name: DATABASE_SERVICE_NAME
+  required: true
+  value: postgresql
+- description: Username for PostgreSQL user that will be used for accessing the database.
+  displayName: PostgreSQL Connection Username
+  from: user[A-Z0-9]{3}
+  generate: expression
+  name: POSTGRESQL_USER
+  required: true
+- description: Password for the PostgreSQL connection user.
+  displayName: PostgreSQL Connection Password
+  from: '[a-zA-Z0-9]{16}'
+  generate: expression
+  name: POSTGRESQL_PASSWORD
+  required: true
+- description: Name of the PostgreSQL database accessed.
+  displayName: PostgreSQL Database Name
+  name: POSTGRESQL_DATABASE
+  required: true
+  value: sampledb
+- description: Password for the PostgreSQL admin user.
+  displayName: PostgreSQL admin 'postgresql' Password
+  from: '[a-zA-Z0-9]{16}'
+  name: POSTGRESQL_ADMIN_PASSWORD
+  required: true
+- description: Volume space available for data, e.g. 512Mi, 2Gi.
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  value: 2Gi


### PR DESCRIPTION
Added 2 new templates to support the application deployment on OpenShift, both ephemeral and persistent versions, backed by PostgreSQL on the persistent case.